### PR TITLE
Use adserver-graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `store-resources` dependency.
+
+### Added
+
+- `adserver-graphql` dependency.
+
 ## [0.0.3] - 2024-11-06
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -11,14 +11,12 @@
     "store": "0.x"
   },
   "dependencies": {
-    "vtex.store-resources": "0.x",
     "vtex.device-detector": "0.x",
     "vtex.styleguide": "9.x",
-    "vtex.css-handles": "1.x"
+    "vtex.css-handles": "1.x",
+    "vtex.adserver-graphql": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/__mocks__/vtex.store-resources/QuerySponsoredBanners.js
+++ b/react/__mocks__/vtex.store-resources/QuerySponsoredBanners.js
@@ -1,1 +1,0 @@
-export default function sponsoredBannersQuery() {}

--- a/react/components/SponsoredBanner/__test__/useSponsoredBanner.test.ts
+++ b/react/components/SponsoredBanner/__test__/useSponsoredBanner.test.ts
@@ -22,6 +22,10 @@ jest.mock('vtex.device-detector', () => ({
   useDevice: jest.fn(),
 }))
 
+jest.mock('../../../query', () => ({
+  sponsoredBannersQuery: jest.fn(),
+}))
+
 describe('useSponsoredBanner hook', () => {
   describe('when it has data without error', () => {
     beforeEach(() => {

--- a/react/components/SponsoredBanner/useSponsoredBanner.ts
+++ b/react/components/SponsoredBanner/useSponsoredBanner.ts
@@ -1,8 +1,8 @@
 import { useQuery } from 'react-apollo'
 import { useIntl } from 'react-intl'
 import { useDevice } from 'vtex.device-detector'
-import sponsoredBannersQuery from 'vtex.store-resources/QuerySponsoredBanners'
 
+import sponsoredBannersQuery from '../../query'
 import messages from '../../messages'
 import type {
   SponsoredBannersData,

--- a/react/package.json
+++ b/react/package.json
@@ -14,8 +14,8 @@
     "react-dom": "^16.12.0",
     "react-intl": "^3.12.0",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.101.1/public/@types/vtex.store-resources",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide",
+    "vtex.adserver-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.3.1/public/@types/vtex.adserver-graphql"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",

--- a/react/query/index.ts
+++ b/react/query/index.ts
@@ -1,0 +1,3 @@
+import QuerySponsoredBanners from './sponsoredBanners.gql'
+
+export default QuerySponsoredBanners

--- a/react/query/sponsoredBanners.gql
+++ b/react/query/sponsoredBanners.gql
@@ -1,0 +1,24 @@
+query sponsoredBanners(
+  $sponsoredCount: Int
+  $placement: Placement
+  $adUnit: AdUnit
+  $channel: Channel
+  $anonymousId: String
+) {
+  sponsoredBanners(
+    sponsoredCount: $sponsoredCount
+    placement: $placement
+    adUnit: $adUnit
+    channel: $channel
+    anonymousId: $anonymousId
+  ) @context(provider: "vtex.adserver-graphql") {
+    adResponseId
+    advertisement {
+      bannerImageId
+      imageUrl
+      targetUrl
+      width
+      height
+    }
+  }
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6051,13 +6051,13 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.adserver-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.3.1/public/@types/vtex.adserver-graphql":
+  version "0.3.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.3.1/public/@types/vtex.adserver-graphql#7bc21e63846ac77bf60d1d873e9f7fd3917b2707"
+
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles":
   version "1.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
-
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.101.1/public/@types/vtex.store-resources":
-  version "0.101.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.101.1/public/@types/vtex.store-resources#886858b2d64ac5b0c92fd21b7f855c821a6efc9b"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide":
   version "9.146.9"


### PR DESCRIPTION
#### What problem is this solving?

Use `adserver-graphql` to call Adserver data directly to graphql, removing `store-resources` dependency.

#### How to test it?

[Workspace](https://sponsoredbanners--biggy.myvtex.com)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

- adserver-graphql

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/11ISwbgCxEzMyY/giphy.gif?cid=790b7611bl9i3wtccvtsp6f3erp01td4srrxhog6lh69njd7&ep=v1_gifs_search&rid=giphy.gif&ct=g)
