### PR TITLE
Change css handles version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Downgrade `vtex.css-handles` version.
+
 ## [0.0.4] - 2024-11-07
 
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -13,12 +13,10 @@
   "dependencies": {
     "vtex.device-detector": "0.x",
     "vtex.styleguide": "9.x",
-    "vtex.css-handles": "1.x",
+    "vtex.css-handles": "0.x",
     "vtex.adserver-graphql": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/SponsoredBanner/SponsoredBanner.tsx
+++ b/react/components/SponsoredBanner/SponsoredBanner.tsx
@@ -6,8 +6,6 @@ import { useSponsoredBanner } from './useSponsoredBanner'
 import { getDataProperties } from '../../utils'
 import type { SponsoredBannersProps } from '../../interfaces'
 
-import './styles.css'
-
 const CSS_HANDLES = ['bannerWrapper', 'bannerImage'] as const
 
 export const SponsoredBanner = (props: SponsoredBannersProps) => {
@@ -36,6 +34,7 @@ export const SponsoredBanner = (props: SponsoredBannersProps) => {
         maxWidth: banner.advertisement.width,
         height: 'auto',
         aspectRatio: `${styleProps.ratio}`,
+        margin: '0 auto',
       }}
     >
       {loading ? (

--- a/react/components/SponsoredBanner/styles.css
+++ b/react/components/SponsoredBanner/styles.css
@@ -1,3 +1,0 @@
-.bannerWrapper {
-  margin: 0 auto;
-}

--- a/react/package.json
+++ b/react/package.json
@@ -13,7 +13,6 @@
     "react-apollo": "^3.1.3",
     "react-dom": "^16.12.0",
     "react-intl": "^3.12.0",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide",
     "vtex.adserver-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.3.1/public/@types/vtex.adserver-graphql"
   },

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6055,10 +6055,6 @@ verror@1.10.0:
   version "0.3.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.adserver-graphql@0.3.1/public/@types/vtex.adserver-graphql#7bc21e63846ac77bf60d1d873e9f7fd3917b2707"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles":
-  version "1.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
-
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide":
   version "9.146.9"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide#d1601fedfb665c6173334753171717da64e670bc"


### PR DESCRIPTION
#### What problem is this solving?

vtx.css-handles version 1.x was broken, so it was necessary change it to 0.x version.

#### Screenshots or example usage:

Before:
![image (6)](https://github.com/user-attachments/assets/fbcecfb8-c791-4923-9f9f-5945acff5523)

After:
<img width="319" alt="image" src="https://github.com/user-attachments/assets/809aef18-ca4f-4d59-aab6-6794febc2584">
